### PR TITLE
adding name as opt_field for workspace and tags

### DIFF
--- a/asana/cache.go
+++ b/asana/cache.go
@@ -44,7 +44,7 @@ func printBasics(title string, bs []Basic) {
 // updateTags updates the tags. Appropriate locks should be acquired by the caller.
 func (c *acache) updateTags() error {
 	var err error
-	c.tags, err = getVarious("tags")
+	c.tags, err = getVarious("tags", "name")
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func (c *acache) update() error {
 	defer c.Unlock()
 
 	var err error
-	c.workspaces, err = getVarious("workspaces")
+	c.workspaces, err = getVarious("workspaces", "name")
 	if err != nil {
 		return errors.Wrap(err, "workspaces")
 	}


### PR DESCRIPTION
PR to solve [issue 29](https://github.com/manishrjain/asanawarrior/issues/29). As adding `name` as opt field will ensure we will always get name for workspaces and tags.